### PR TITLE
Update wrapped-profileFormText.ts

### DIFF
--- a/src/editProfilePane/wrapped-profileFormText.ts
+++ b/src/editProfilePane/wrapped-profileFormText.ts
@@ -50,7 +50,7 @@ export const profileForm= `
 
 # Nickname
 
-:nicknameField a ui:SingleLineTextField; ui:size 12; ui:property foaf:nick;
+:nicknameField a ui:SingleLineTextField; ui:maxLength "20"; ui:size 12; ui:property foaf:nick;
       ui:label "Short name for chats, etc."@en, "nom court"@fr.
 
  # Pronouns


### PR DESCRIPTION
I believe that since it says "Short name for chats, etc" a reasonable starting place may be a 20 character limit. If characters are increased, this will lead to spammed/ugly profile homepages. I tested the 20 character limit with the default browser setting at 100% zoom function. It does not interfere with the cards aesthetic. It seems like it stays in its container and looks encapsulated. Also checked this out on the smartphone and it seems safe. I also noticed that there are two wrapped-profileFormText.ts files that seem identical. Place this where you will. If this is not fixed, users will exploit this and spam to infinity.