### PR TITLE
a11y: drop inner <main> from ProfileView and EditProfileView

### DIFF
--- a/src/ProfileView.ts
+++ b/src/ProfileView.ts
@@ -90,7 +90,7 @@ export async function ProfileView (
         data-theme=${theme}
         data-input-mode=${inputMode}
       >
-        <main
+        <div
           id="main-content"
           class="profile-grid"
           tabindex="-1"
@@ -107,7 +107,7 @@ export async function ProfileView (
           ${socialSection}
           ${contactInfoSection}
           ${qrCodeSection}
-        </main>
+        </div>
       </div>
     `
   }

--- a/src/editProfilePane/EditProfileView.ts
+++ b/src/editProfilePane/EditProfileView.ts
@@ -41,8 +41,8 @@ const editProfileView: PaneDefinition = {
     div.setAttribute('aria-label', 'Edit your profile')
     let editableProfile: NamedNode | null
 
-    // Use <main> for the main content area, styled as a grid like ProfileView
-    const main = dom.createElement('main')
+    // Pane root content. The page-level <main> landmark is on the shell's #MainContent.
+    const main = dom.createElement('div')
     main.setAttribute('id', 'profile-edit-main-content')
     main.setAttribute('aria-busy', 'true')
     main.setAttribute('tabindex', '-1')


### PR DESCRIPTION
## Summary
- Both views wrapped their grid content in a `<main>`. With the shell's `#MainContent` also being a `<main>`, profile-pane pages had two nested `<main>` landmarks.
- The page-level `<main>` landmark now lives on the shell's `.app-view` (see SolidOS/mashlib#394). Demote the inner element to a `<div>`, preserving id, class, and tabindex.

Addresses #310.

## Coordinated PRs
- SolidOS/mashlib#394 — Promote `.app-view` to the page-level `<main>` landmark (land first)
- SolidOS/solid-ui#747 — Demote tab-widget body from `<main>` to `<div>`