### PR TITLE
#342 Resume: Reverse org type and name

### DIFF
--- a/src/sections/resume/ResumeEditDialog.ts
+++ b/src/sections/resume/ResumeEditDialog.ts
@@ -192,6 +192,21 @@ function getAllowedOrganizationTypeIds(selectedType: string): string[] {
     .filter(Boolean)
 }
 
+const allowedOrganizationTypeIdSetCache = new Map<string, Set<string>>()
+
+function getAllowedOrganizationTypeIdSet(selectedType: string): Set<string> {
+  const normalizedType = normalizeResumeOrganizationTypeValue(selectedType)
+  const cachedIds = allowedOrganizationTypeIdSetCache.get(normalizedType)
+
+  if (cachedIds) {
+    return cachedIds
+  }
+
+  const allowedIds = new Set(getAllowedOrganizationTypeIds(normalizedType))
+  allowedOrganizationTypeIdSetCache.set(normalizedType, allowedIds)
+  return allowedIds
+}
+
 async function fetchWikidataEntities(ids: string[]): Promise<Record<string, WikidataEntity>> {
   const uniqueIds = Array.from(new Set(ids.filter(Boolean)))
   if (!uniqueIds.length || typeof fetch !== 'function') return {}
@@ -208,7 +223,7 @@ function entityMatchesAllowedOrganizationTypes(
   entityMap: Record<string, WikidataEntity>,
   selectedType: string
 ): boolean {
-  const allowedIds = new Set(getAllowedOrganizationTypeIds(selectedType))
+  const allowedIds = getAllowedOrganizationTypeIdSet(selectedType)
   const visited = new Set<string>()
   const agenda = [entityId]
 

--- a/src/sections/resume/ResumeEditDialog.ts
+++ b/src/sections/resume/ResumeEditDialog.ts
@@ -177,6 +177,21 @@ function getWikidataClaimIds(entity: WikidataEntity | undefined, property: 'P31'
     .filter((id): id is string => typeof id === 'string' && id.length > 0)
 }
 
+function getAllowedOrganizationTypeIds(selectedType: string): string[] {
+  const normalizedType = normalizeResumeOrganizationTypeValue(selectedType)
+  const typeUris = RESUME_ORGANIZATION_TYPE_WIKIDATA_CLASS_URIS[normalizedType]
+
+  if (!typeUris?.length) {
+    return RESUME_ORGANIZATION_SEARCH_CLASS_URIS
+      .map((uri) => getWikidataIdFromUri(uri))
+      .filter(Boolean)
+  }
+
+  return typeUris
+    .map((uri) => getWikidataIdFromUri(uri))
+    .filter(Boolean)
+}
+
 async function fetchWikidataEntities(ids: string[]): Promise<Record<string, WikidataEntity>> {
   const uniqueIds = Array.from(new Set(ids.filter(Boolean)))
   if (!uniqueIds.length || typeof fetch !== 'function') return {}
@@ -188,10 +203,12 @@ async function fetchWikidataEntities(ids: string[]): Promise<Record<string, Wiki
   return payload?.entities || {}
 }
 
-function entityMatchesAllowedOrganizationTypes(entityId: string, entityMap: Record<string, WikidataEntity>): boolean {
-  const allowedIds = new Set(
-    RESUME_ORGANIZATION_SEARCH_CLASS_URIS.map((uri) => getWikidataIdFromUri(uri))
-  )
+function entityMatchesAllowedOrganizationTypes(
+  entityId: string,
+  entityMap: Record<string, WikidataEntity>,
+  selectedType: string
+): boolean {
+  const allowedIds = new Set(getAllowedOrganizationTypeIds(selectedType))
   const visited = new Set<string>()
   const agenda = [entityId]
 
@@ -243,7 +260,10 @@ function dedupeResumeOrganizationSuggestions(
   })
 }
 
-async function fetchWikidataOrganizationSuggestions(name: string): Promise<ResumeOrganizationSuggestion[]> {
+async function fetchWikidataOrganizationSuggestions(
+  name: string,
+  selectedType: string
+): Promise<ResumeOrganizationSuggestion[]> {
   const query = sanitizeResumeFieldValue(name)
   if (query.length < 2 || typeof fetch !== 'function') return []
 
@@ -283,11 +303,10 @@ async function fetchWikidataOrganizationSuggestions(name: string): Promise<Resum
 
     const filteredSuggestions = suggestions.filter((suggestion) => {
       const entityId = getWikidataIdFromUri(suggestion.publicId)
-      return entityMatchesAllowedOrganizationTypes(entityId, entityMap)
+      return entityMatchesAllowedOrganizationTypes(entityId, entityMap, selectedType)
     })
 
-    return (filteredSuggestions.length > 0 ? filteredSuggestions : suggestions)
-      .slice(0, WIKIDATA_ORGANIZATION_SEARCH_LIMIT)
+    return filteredSuggestions.slice(0, WIKIDATA_ORGANIZATION_SEARCH_LIMIT)
   } catch {
     return []
   }
@@ -325,9 +344,11 @@ function readResumeOrganizationComboboxChange(event: Event): ResumeOrganizationC
   return null
 }
 
-function createResumeOrganizationSuggestionProvider(): (query: string) => Promise<ResumeOrganizationComboboxOption[]> {
+function createResumeOrganizationSuggestionProvider(
+  getSelectedType: () => string
+): (query: string) => Promise<ResumeOrganizationComboboxOption[]> {
   return async (query: string) => {
-    const suggestions = await fetchWikidataOrganizationSuggestions(query)
+    const suggestions = await fetchWikidataOrganizationSuggestions(query, getSelectedType())
     return suggestions.map(toResumeOrganizationComboboxOption)
   }
 }
@@ -562,7 +583,9 @@ function initializeResumeOrganizationComboboxes(form: HTMLFormElement, resumeDat
       ? [{ label: resumeRow.orgName, value: resumeRow.orgPublicId, publicId: resumeRow.orgPublicId }]
       : []
 
-    comboboxElement.suggestionProvider = createResumeOrganizationSuggestionProvider()
+    comboboxElement.suggestionProvider = createResumeOrganizationSuggestionProvider(
+      () => normalizeResumeOrganizationTypeValue(resumeRow.orgType || '')
+    )
     comboboxElement.options = options
     comboboxElement.value = resumeRow.orgPublicId || ''
     comboboxElement.inputValue = resumeRow.orgName || ''
@@ -742,6 +765,7 @@ function renderResumeInputRow({
     const nextType = normalizeResumeOrganizationTypeValue(readResumeOrganizationTypeChange(e))
     if (resumeRow) {
       applyRowSelectChange(resumeRow, 'orgType', nextType)
+      resumeRow.orgPublicId = ''
       onChange()
     }
   }
@@ -796,16 +820,6 @@ function renderResumeInputRow({
       />
     </label>
     <div class="profile-edit-dialog__row">
-      <label aria-label=${`${label} Organization Name`} class="label profile-edit-dialog__field">
-        Company or Organization 
-        <solid-ui-combobox
-          name=${organizationName}
-          data-resume-organization-index=${String(index)}
-          required
-          @input=${handleOrganizationNameInput}
-          @change=${handleOrganizationNameChange}
-        ></solid-ui-combobox>
-      </label>
       <label aria-label=${`${label} Organization Type`} class="label profile-edit-dialog__field">
         Organization Type
         <solid-ui-select
@@ -818,6 +832,16 @@ function renderResumeInputRow({
           .label=${''}
           @change=${handleOrganizationTypeInput}
         ></solid-ui-select>
+      </label>
+      <label aria-label=${`${label} Organization Name`} class="label profile-edit-dialog__field">
+        Company or Organization 
+        <solid-ui-combobox
+          name=${organizationName}
+          data-resume-organization-index=${String(index)}
+          required
+          @input=${handleOrganizationNameInput}
+          @change=${handleOrganizationNameChange}
+        ></solid-ui-combobox>
       </label>
     </div>  
     <div class="profile-edit-dialog__row">

--- a/src/sections/resume/ResumeEditDialog.ts
+++ b/src/sections/resume/ResumeEditDialog.ts
@@ -260,7 +260,7 @@ function dedupeResumeOrganizationSuggestions(
   })
 }
 
-async function fetchWikidataOrganizationSuggestions(
+export async function fetchWikidataOrganizationSuggestions(
   name: string,
   selectedType: string
 ): Promise<ResumeOrganizationSuggestion[]> {

--- a/test/sections/resume.selectors-mutations.test.ts
+++ b/test/sections/resume.selectors-mutations.test.ts
@@ -1,11 +1,17 @@
-import { describe, expect, it } from "@jest/globals"
+import { beforeEach, describe, expect, it } from "@jest/globals"
+import fetchMock from 'jest-fetch-mock'
 import { graph, literal, sym } from 'rdflib'
 import { ns } from 'solid-ui'
 import { presentCV } from '../../src/sections/resume/selectors'
 import { processResumeMutations } from '../../src/sections/resume/mutations'
+import { fetchWikidataOrganizationSuggestions } from '../../src/sections/resume/ResumeEditDialog'
 import { saveResumeUpdatesFailedMessageText, updaterUnsupportedStoreErrorMessageText } from '../../src/texts'
 
 describe('Resume selectors and mutations', () => {
+  beforeEach(() => {
+    fetchMock.resetMocks()
+  })
+
   it('selector returns empty roles from empty store', () => {
     const store = graph() as any
     const subject = sym('https://example.com/profile/card#me')
@@ -363,5 +369,86 @@ describe('Resume selectors and mutations', () => {
     expect(deletionKeys.has(`${membership.value} ${ns.org('organization').value} ${organization.value}`)).toBe(true)
     expect(deletionKeys.has(`${organization.value} ${ns.schema('name').value} Google`)).toBe(true)
     expect(deletionKeys.has(`${organization.value} ${ns.org('location').value} San Diego`)).toBe(true)
+  })
+
+  it('filters Wikidata organization suggestions by the selected organization type', async () => {
+    const searchPayload = {
+      search: [
+        {
+          id: 'Q100001',
+          label: 'SolidOS Inc',
+          concepturi: 'http://www.wikidata.org/entity/Q100001'
+        },
+        {
+          id: 'Q100002',
+          label: 'SolidOS University',
+          concepturi: 'http://www.wikidata.org/entity/Q100002'
+        }
+      ]
+    }
+
+    const entityPayload = {
+      entities: {
+        Q100001: {
+          claims: {
+            P31: [
+              {
+                mainsnak: {
+                  snaktype: 'value',
+                  datavalue: {
+                    value: { id: 'Q6881511' }
+                  }
+                }
+              }
+            ]
+          }
+        },
+        Q100002: {
+          claims: {
+            P31: [
+              {
+                mainsnak: {
+                  snaktype: 'value',
+                  datavalue: {
+                    value: { id: 'Q178706' }
+                  }
+                }
+              }
+            ]
+          }
+        }
+      }
+    }
+
+    fetchMock.mockResponses(
+      [JSON.stringify(searchPayload), { status: 200 }],
+      [JSON.stringify(entityPayload), { status: 200 }],
+      [JSON.stringify({ entities: {} }), { status: 200 }]
+    )
+
+    const corporationSuggestions = await fetchWikidataOrganizationSuggestions('solid', 'Corporation')
+
+    expect(corporationSuggestions).toEqual([
+      {
+        label: 'SolidOS Inc',
+        publicId: 'http://www.wikidata.org/entity/Q100001'
+      }
+    ])
+
+    fetchMock.resetMocks()
+    fetchMock.mockResponses(
+      [JSON.stringify(searchPayload), { status: 200 }],
+      [JSON.stringify(entityPayload), { status: 200 }],
+      [JSON.stringify({ entities: {} }), { status: 200 }]
+    )
+
+    const educationalSuggestions = await fetchWikidataOrganizationSuggestions('solid', 'EducationalOrganization')
+
+    expect(educationalSuggestions).toEqual([
+      {
+        label: 'SolidOS University',
+        publicId: 'http://www.wikidata.org/entity/Q100002'
+      }
+    ])
   })
 })


### PR DESCRIPTION
Put organizational type first and then name and base the wikidata search on the type chosen by the user.