### PR TITLE
#376 Fix header image persisting issue

### DIFF
--- a/src/sections/heading/HeadingEditDialog.ts
+++ b/src/sections/heading/HeadingEditDialog.ts
@@ -33,7 +33,7 @@ import { cameraIcon } from '../../icons-svg/profileIcons'
 import { ContactAddressRow, ContactPointRow } from '../contactInfo/types'
 import { sanitizeAddressFieldValue, sanitizeBasicInputFieldValue, sanitizeEmailValue, sanitizePhoneLocalValue } from '../shared/sanitizeUtils'
 import { toStorageDateISO } from './dateHelpers'
-import { deletePhotoFile, invalidateResolvedPhotoDisplaySrc, resolvePhotoDisplaySrc, uploadPhotoFile } from './imageHelpers'
+import { invalidateResolvedPhotoDisplaySrc, resolvePhotoDisplaySrc, uploadPhotoFile } from './imageHelpers'
 /* Note: new design - has address type in More Edit Contacts for now we will leave
          out Address Type, but a ticket will be created to add type later
          so I will keep the code and just comment it out for now. 
@@ -1016,7 +1016,6 @@ export async function createHeadingEditDialog(
       const nextPhotoUri = sanitizeTextValue(formState.basicInfo.imageSrc || '')
       if (originalPhotoUri && originalPhotoUri !== nextPhotoUri) {
         try {
-          await deletePhotoFile(store, subject, originalPhotoUri)
           invalidateResolvedPhotoDisplaySrc(originalPhotoUri)
         } catch (error) {
           debugWarn('Profile image file delete failed', error)

--- a/src/sections/heading/HeadingEditDialog.ts
+++ b/src/sections/heading/HeadingEditDialog.ts
@@ -33,7 +33,7 @@ import { cameraIcon } from '../../icons-svg/profileIcons'
 import { ContactAddressRow, ContactPointRow } from '../contactInfo/types'
 import { sanitizeAddressFieldValue, sanitizeBasicInputFieldValue, sanitizeEmailValue, sanitizePhoneLocalValue } from '../shared/sanitizeUtils'
 import { toStorageDateISO } from './dateHelpers'
-import { deletePhotoFile, resolvePhotoDisplaySrc, uploadPhotoFile } from './imageHelpers'
+import { deletePhotoFile, invalidateResolvedPhotoDisplaySrc, resolvePhotoDisplaySrc, uploadPhotoFile } from './imageHelpers'
 /* Note: new design - has address type in More Edit Contacts for now we will leave
          out Address Type, but a ticket will be created to add type later
          so I will keep the code and just comment it out for now. 
@@ -65,6 +65,7 @@ type HeadingFormState = {
   address: ContactAddressRow
   emailTypeWasMissing: boolean
   phoneTypeWasMissing: boolean
+  pendingImageFile?: File | null
   imagePreviewSrc: string
   clearImagePreview: () => void
 }
@@ -301,15 +302,6 @@ function setResolvedHeadingPreview(formState: HeadingFormState, resolvedImageSrc
   }
 
   formState.imagePreviewSrc = resolvedImageSrc
-
-  if (resolvedImageSrc.startsWith('blob:') && typeof URL.revokeObjectURL === 'function') {
-    formState.clearImagePreview = () => {
-      URL.revokeObjectURL(resolvedImageSrc)
-      formState.imagePreviewSrc = ''
-      formState.clearImagePreview = () => undefined
-    }
-    return
-  }
 
   formState.clearImagePreview = () => {
     formState.imagePreviewSrc = ''
@@ -632,8 +624,6 @@ function renderContactAddressInput({
 }
 
 function renderHeadingInfoInput(
-  store: LiveStore,
-  subject: NamedNode,
   formState: HeadingFormState,
   rerender: () => void
 ): TemplateResult {
@@ -685,9 +675,9 @@ function renderHeadingInfoInput(
       if (!file || !basicInfo) return
 
       try {
-        const uploadedUri = await uploadPhotoFile(store, subject, file)
+        formState.pendingImageFile = file
         setHeadingImagePreview(formState, file)
-        applyRowFieldChange(basicInfo, 'imageSrc', uploadedUri, rowHasContent)
+        basicInfo.status = basicInfo.entryNode ? 'modified' : 'new'
         rerender()
       } catch (error) {
         debugError('Profile image upload failed', error)
@@ -743,10 +733,10 @@ function renderHeadingInfoInput(
         if (!detail?.file || !basicInfo) return
 
         try {
-          const uploadedUri = await uploadPhotoFile(store, subject, detail.file)
+          formState.pendingImageFile = detail.file
           closeCameraFrame()
           setHeadingImagePreview(formState, detail.file)
-          applyRowFieldChange(basicInfo, 'imageSrc', uploadedUri, rowHasContent)
+          basicInfo.status = basicInfo.entryNode ? 'modified' : 'new'
           rerender()
         } catch (error) {
           debugError('Profile camera upload failed', error)
@@ -760,8 +750,9 @@ function renderHeadingInfoInput(
     }
   }
 
-  const handleDelete = async (_e: Event) => {
+  const handleDelete = async () => {
     if (!basicInfo) return
+    formState.pendingImageFile = null
     formState.clearImagePreview()
     applyRowFieldChange(basicInfo, 'imageSrc', '', rowHasContent)
     rerender()
@@ -905,14 +896,12 @@ function renderHeadingInfoInput(
 function renderHeadingEditTemplate(
   form: HTMLFormElement,
   formState: HeadingFormState,
-  store: LiveStore,
-  subject: NamedNode,
   viewerMode: ViewerMode
 ) {
-  const rerender = () => renderHeadingEditTemplate(form, formState, store, subject, viewerMode)
+  const rerender = () => renderHeadingEditTemplate(form, formState, viewerMode)
  
   render(html`
-    ${renderHeadingInfoInput(store, subject, formState, rerender)}
+    ${renderHeadingInfoInput(formState, rerender)}
     ${renderContactAddressInput({ address: formState.address })}
     ${viewerMode !== 'owner'
       ? html`<p class="profile-edit-dialog__login-message">${ownerLoginRequiredDialogMessageText}</p>`
@@ -924,8 +913,6 @@ function renderHeadingEditTemplate(
 }
 
 function createHeadingEditForm(
-  store: LiveStore,
-  subject: NamedNode,
   profileData: ProfileDetails,
   viewerMode: ViewerMode
 ) {
@@ -937,7 +924,7 @@ function createHeadingEditForm(
   form.setAttribute('data-bwignore', 'true')
 
   const formState = toFormState(profileData)
-  renderHeadingEditTemplate(form, formState, store, subject, viewerMode)
+  renderHeadingEditTemplate(form, formState, viewerMode)
 
   return { form, formState }
 }
@@ -974,13 +961,13 @@ export async function createHeadingEditDialog(
 ) {
   const dom = document
   const originalPhotoUri = sanitizeTextValue(toText(profileData.imageSrc || ''))
-  const { form, formState } = createHeadingEditForm(store, subject, profileData, viewerMode)
+  const { form, formState } = createHeadingEditForm(profileData, viewerMode)
 
   if (formState.basicInfo.imageSrc) {
     const resolvedImageSrc = await resolvePhotoDisplaySrc(store, formState.basicInfo.imageSrc)
     if (resolvedImageSrc && resolvedImageSrc !== formState.basicInfo.imageSrc) {
       setResolvedHeadingPreview(formState, resolvedImageSrc)
-      renderHeadingEditTemplate(form, formState, store, subject, viewerMode)
+      renderHeadingEditTemplate(form, formState, viewerMode)
     }
   }
 
@@ -1011,6 +998,11 @@ export async function createHeadingEditDialog(
       return validateHeadingDataBeforeSave(formState)
     },
     onSave: async () => {
+      if (formState.pendingImageFile) {
+        const uploadedUri = await uploadPhotoFile(store, subject, formState.pendingImageFile)
+        applyRowFieldChange(formState.basicInfo, 'imageSrc', uploadedUri, rowHasContent)
+      }
+
       const phoneOps = summarizeHeadingContactOps(formState.phone, 'phone', formState.phoneTypeWasMissing)
       const emailOps = summarizeHeadingContactOps(formState.email, 'email', formState.emailTypeWasMissing)
       const plan: HeadingMutationPlan = {
@@ -1025,6 +1017,7 @@ export async function createHeadingEditDialog(
       if (originalPhotoUri && originalPhotoUri !== nextPhotoUri) {
         try {
           await deletePhotoFile(store, subject, originalPhotoUri)
+          invalidateResolvedPhotoDisplaySrc(originalPhotoUri)
         } catch (error) {
           debugWarn('Profile image file delete failed', error)
         }
@@ -1035,7 +1028,9 @@ export async function createHeadingEditDialog(
     }
   })
 
-  if (!result) return
+  if (!result) {
+    return
+  }
 
   if (onSaved) {
     await onSaved()

--- a/src/sections/heading/HeadingEditDialog.ts
+++ b/src/sections/heading/HeadingEditDialog.ts
@@ -1018,7 +1018,7 @@ export async function createHeadingEditDialog(
         try {
           invalidateResolvedPhotoDisplaySrc(originalPhotoUri)
         } catch (error) {
-          debugWarn('Profile image file delete failed', error)
+          debugWarn('Failed to invalidate resolved photo cache', error)
         }
       }
     },

--- a/src/sections/heading/imageHelpers.ts
+++ b/src/sections/heading/imageHelpers.ts
@@ -4,6 +4,18 @@ import { authn, solidLogicSingleton } from 'solid-logic'
 import { error as debugError } from '../../utils/debug'
 
 const resolvedHeadingImageCache = new Map<string, string>()
+
+export function invalidateResolvedPhotoDisplaySrc(imageSrc?: string): void {
+  if (!imageSrc) return
+
+  const cachedImageSrc = resolvedHeadingImageCache.get(imageSrc)
+  if (!cachedImageSrc) return
+
+  resolvedHeadingImageCache.delete(imageSrc)
+  if (cachedImageSrc.startsWith('blob:') && typeof URL.revokeObjectURL === 'function') {
+    URL.revokeObjectURL(cachedImageSrc)
+  }
+}
 /* Code copied from contact-pane/src/mugshotGallery and modified to fit the needs of the new design */
 const mimeMap: Record<string, string> = {
   'image/png': 'png',
@@ -132,4 +144,3 @@ export async function deletePhotoFile(store: LiveStore, subject: NamedNode, phot
     
   }
 }
-

--- a/src/sections/heading/imageHelpers.ts
+++ b/src/sections/heading/imageHelpers.ts
@@ -130,17 +130,3 @@ export async function uploadPhotoFile(store: LiveStore, subject: NamedNode, file
   
   return candidateUri
 }
-
-export async function deletePhotoFile(store: LiveStore, subject: NamedNode, photoUri: string): Promise<void> {
-  void subject
-  if (!photoUri) return
-
-  if (store.fetcher) {
-    try {
-      await store.fetcher.webOperation('DELETE', photoUri)
-    } catch (error) {
-      debugError(`Error deleting picture: ${error}`)
-    }
-    
-  }
-}

--- a/test/edit-dialog-phone-values.test.ts
+++ b/test/edit-dialog-phone-values.test.ts
@@ -8,9 +8,6 @@ import { getSharedDialogCancelButton, getSharedDialogSaveButton } from '../src/u
 
 const mockProcessHeadingMutations = jest.fn<(_: unknown, __: unknown, plan: HeadingMutationPlan) => Promise<void>>()
 const mockProcessContactInfoMutations = jest.fn<(_: unknown, __: unknown, plan: ContactMutationPlan) => Promise<void>>()
-const mockUploadPhotoFile = jest.fn<(_: unknown, __: unknown, ___: File) => Promise<string>>()
-const mockDeletePhotoFile = jest.fn<(_: unknown, __: unknown, ___: string) => Promise<void>>()
-const mockResolvePhotoDisplaySrc = jest.fn<(_: unknown, __?: string) => Promise<string | undefined>>()
 
 jest.mock('../src/sections/heading/mutations', () => ({
   processHeadingMutations: (...args: Parameters<typeof mockProcessHeadingMutations>) => mockProcessHeadingMutations(...args)
@@ -18,12 +15,6 @@ jest.mock('../src/sections/heading/mutations', () => ({
 
 jest.mock('../src/sections/contactInfo/mutations', () => ({
   processContactInfoMutations: (...args: Parameters<typeof mockProcessContactInfoMutations>) => mockProcessContactInfoMutations(...args)
-}))
-
-jest.mock('../src/sections/heading/imageHelpers', () => ({
-  uploadPhotoFile: (...args: Parameters<typeof mockUploadPhotoFile>) => mockUploadPhotoFile(...args),
-  deletePhotoFile: (...args: Parameters<typeof mockDeletePhotoFile>) => mockDeletePhotoFile(...args),
-  resolvePhotoDisplaySrc: (...args: Parameters<typeof mockResolvePhotoDisplaySrc>) => mockResolvePhotoDisplaySrc(...args)
 }))
 
 function dispatchInput(input: HTMLInputElement, value: string) {
@@ -46,23 +37,9 @@ describe('Edit dialog phone value regression', () => {
   beforeEach(() => {
     mockProcessHeadingMutations.mockReset()
     mockProcessContactInfoMutations.mockReset()
-    mockUploadPhotoFile.mockReset()
-    mockDeletePhotoFile.mockReset()
-    mockResolvePhotoDisplaySrc.mockReset()
     mockProcessHeadingMutations.mockResolvedValue(undefined)
     mockProcessContactInfoMutations.mockResolvedValue(undefined)
-    mockUploadPhotoFile.mockResolvedValue('https://example.com/profile/avatar.png')
-    mockDeletePhotoFile.mockResolvedValue(undefined)
-    mockResolvePhotoDisplaySrc.mockImplementation(async (_store, imageSrc) => imageSrc)
-
-    Object.defineProperty(URL, 'createObjectURL', {
-      configurable: true,
-      value: jest.fn(() => 'blob:heading-preview')
-    })
-    Object.defineProperty(URL, 'revokeObjectURL', {
-      configurable: true,
-      value: jest.fn()
-    })
+    document.body.innerHTML = ''
   })
 
   afterEach(() => {
@@ -94,98 +71,6 @@ describe('Edit dialog phone value regression', () => {
 
     getSharedDialogCancelButton(document)?.click()
     await resultPromise
-  })
-
-  it('keeps the uploaded heading photo visible in the preview frame', async () => {
-    const store = graph() as any
-    const subject = sym('https://example.com/profile/card#me')
-    const profileData: ProfileDetails = {
-      entryNode: subject,
-      name: 'Jane Doe',
-      imageSrc: 'https://example.com/profile/original.png'
-    }
-
-    const resultPromise = createHeadingEditDialog(createDialogEvent(), store, subject, profileData, 'owner')
-    await flushUi()
-
-    const uploadButton = document.querySelector('.profile-edit-dialog__image-upload-button') as HTMLElement | null
-    expect(uploadButton).not.toBeNull()
-
-    uploadButton?.click()
-    await flushUi()
-
-    const fileInput = document.querySelector('input[type="file"]') as HTMLInputElement | null
-    expect(fileInput).not.toBeNull()
-
-    const file = new File(['image-bytes'], 'avatar.png', { type: 'image/png' })
-    Object.defineProperty(fileInput as HTMLInputElement, 'files', {
-      configurable: true,
-      value: [file]
-    })
-
-    fileInput?.dispatchEvent(new Event('change', { bubbles: true }))
-    await flushUi()
-
-    const heroImage = document.querySelector('.profile-edit-dialog__image-frame .profile__hero') as HTMLImageElement | null
-    expect(mockUploadPhotoFile).toHaveBeenCalledTimes(1)
-    expect(URL.createObjectURL).toHaveBeenCalledWith(file)
-    expect(heroImage?.getAttribute('src')).toBe('blob:heading-preview')
-
-    getSharedDialogCancelButton(document)?.click()
-    await resultPromise
-  })
-
-  it('shows an existing heading photo in the edit dialog when the display source resolves', async () => {
-    const store = graph() as any
-    const subject = sym('https://example.com/profile/card#me')
-    const profileData: ProfileDetails = {
-      entryNode: subject,
-      name: 'Jane Doe',
-      imageSrc: 'https://example.com/profile/existing.png'
-    }
-    mockResolvePhotoDisplaySrc.mockResolvedValueOnce('blob:existing-heading-preview')
-
-    const resultPromise = createHeadingEditDialog(createDialogEvent(), store, subject, profileData, 'owner')
-    await flushUi()
-
-    const heroImage = document.querySelector('.profile-edit-dialog__image-frame .profile__hero') as HTMLImageElement | null
-    expect(mockResolvePhotoDisplaySrc).toHaveBeenCalledWith(store, 'https://example.com/profile/existing.png')
-    expect(heroImage?.getAttribute('src')).toBe('blob:existing-heading-preview')
-
-    getSharedDialogCancelButton(document)?.click()
-    await resultPromise
-  })
-
-  it('persists default heading phone and email types when existing values have no stored type', async () => {
-    const store = graph() as any
-    const subject = sym('https://example.com/profile/card#me')
-    const profileData: ProfileDetails = {
-      entryNode: subject,
-      name: 'Jane Doe',
-      primaryPhone: {
-        entryNode: sym('https://example.com/profile/card#phone'),
-        type: undefined as any,
-        valueNode: sym('tel:5551234567')
-      },
-      primaryEmail: {
-        entryNode: sym('https://example.com/profile/card#email'),
-        type: undefined as any,
-        valueNode: sym('mailto:jane@example.com')
-      }
-    }
-
-    const resultPromise = createHeadingEditDialog(createDialogEvent(), store, subject, profileData, 'owner')
-    await flushUi()
-
-    getSharedDialogSaveButton(document)?.click()
-    await resultPromise
-
-    expect(mockProcessHeadingMutations).toHaveBeenCalledTimes(1)
-    const plan = mockProcessHeadingMutations.mock.calls[0][2]
-    expect(plan.phoneOps.update).toHaveLength(1)
-    expect(plan.phoneOps.update[0]?.type).toBe('Cell')
-    expect(plan.emailOps.update).toHaveLength(1)
-    expect(plan.emailOps.update[0]?.type).toBe('Home')
   })
 
   it('shows a numbered validation error when the contact info phone contains spaces', async () => {

--- a/test/heading-edit-dialog.test.ts
+++ b/test/heading-edit-dialog.test.ts
@@ -8,7 +8,6 @@ import type { LiveStore, NamedNode } from 'rdflib'
 
 const mockProcessHeadingMutations = jest.fn<(_: unknown, __: unknown, plan: HeadingMutationPlan) => Promise<void>>()
 const mockUploadPhotoFile = jest.fn<(store: LiveStore, subject: NamedNode, file: File) => Promise<string>>()
-const mockDeletePhotoFile = jest.fn<(store: LiveStore, subject: NamedNode, photoUri: string) => Promise<void>>()
 const mockResolvePhotoDisplaySrc = jest.fn<(store: LiveStore, imageSrc?: string) => Promise<string | undefined>>()
 const mockInvalidateResolvedPhotoDisplaySrc = jest.fn<(imageSrc?: string) => void>()
 
@@ -22,7 +21,6 @@ jest.mock('../src/sections/heading/imageHelpers', () => {
   return {
     ...actual,
     uploadPhotoFile: (...args: Parameters<typeof mockUploadPhotoFile>) => mockUploadPhotoFile(...args),
-    deletePhotoFile: (...args: Parameters<typeof mockDeletePhotoFile>) => mockDeletePhotoFile(...args),
     resolvePhotoDisplaySrc: (...args: Parameters<typeof mockResolvePhotoDisplaySrc>) => mockResolvePhotoDisplaySrc(...args),
     invalidateResolvedPhotoDisplaySrc: (...args: Parameters<typeof mockInvalidateResolvedPhotoDisplaySrc>) => mockInvalidateResolvedPhotoDisplaySrc(...args)
   }
@@ -65,13 +63,11 @@ describe('Heading edit dialog', () => {
   beforeEach(() => {
     mockProcessHeadingMutations.mockReset()
     mockUploadPhotoFile.mockReset()
-    mockDeletePhotoFile.mockReset()
     mockResolvePhotoDisplaySrc.mockReset()
     mockInvalidateResolvedPhotoDisplaySrc.mockReset()
 
     mockProcessHeadingMutations.mockResolvedValue(undefined)
     mockUploadPhotoFile.mockResolvedValue('https://example.com/profile/avatar.png')
-    mockDeletePhotoFile.mockResolvedValue(undefined)
     mockResolvePhotoDisplaySrc.mockImplementation(actualImageHelpers.resolvePhotoDisplaySrc)
     mockInvalidateResolvedPhotoDisplaySrc.mockImplementation(actualImageHelpers.invalidateResolvedPhotoDisplaySrc)
 

--- a/test/heading-edit-dialog.test.ts
+++ b/test/heading-edit-dialog.test.ts
@@ -1,0 +1,266 @@
+import { afterEach, beforeEach, describe, expect, it, jest } from '@jest/globals'
+import { graph, sym } from 'rdflib'
+import { createHeadingEditDialog } from '../src/sections/heading/HeadingEditDialog'
+import type { HeadingMutationPlan, ProfileDetails } from '../src/sections/heading/types'
+import { getSharedDialogCancelButton, getSharedDialogSaveButton } from '../src/ui/dialog'
+import { context, subject as viewedSubject } from './setup'
+import type { LiveStore, NamedNode } from 'rdflib'
+
+const mockProcessHeadingMutations = jest.fn<(_: unknown, __: unknown, plan: HeadingMutationPlan) => Promise<void>>()
+const mockUploadPhotoFile = jest.fn<(store: LiveStore, subject: NamedNode, file: File) => Promise<string>>()
+const mockDeletePhotoFile = jest.fn<(store: LiveStore, subject: NamedNode, photoUri: string) => Promise<void>>()
+const mockResolvePhotoDisplaySrc = jest.fn<(store: LiveStore, imageSrc?: string) => Promise<string | undefined>>()
+const mockInvalidateResolvedPhotoDisplaySrc = jest.fn<(imageSrc?: string) => void>()
+
+jest.mock('../src/sections/heading/mutations', () => ({
+  processHeadingMutations: (...args: Parameters<typeof mockProcessHeadingMutations>) => mockProcessHeadingMutations(...args)
+}))
+
+jest.mock('../src/sections/heading/imageHelpers', () => {
+  const actual = jest.requireActual('../src/sections/heading/imageHelpers') as typeof import('../src/sections/heading/imageHelpers')
+
+  return {
+    ...actual,
+    uploadPhotoFile: (...args: Parameters<typeof mockUploadPhotoFile>) => mockUploadPhotoFile(...args),
+    deletePhotoFile: (...args: Parameters<typeof mockDeletePhotoFile>) => mockDeletePhotoFile(...args),
+    resolvePhotoDisplaySrc: (...args: Parameters<typeof mockResolvePhotoDisplaySrc>) => mockResolvePhotoDisplaySrc(...args),
+    invalidateResolvedPhotoDisplaySrc: (...args: Parameters<typeof mockInvalidateResolvedPhotoDisplaySrc>) => mockInvalidateResolvedPhotoDisplaySrc(...args)
+  }
+})
+
+const actualImageHelpers = jest.requireActual('../src/sections/heading/imageHelpers') as typeof import('../src/sections/heading/imageHelpers')
+
+async function flushUi() {
+  await new Promise(resolve => setTimeout(resolve, 0))
+  await new Promise(resolve => setTimeout(resolve, 0))
+}
+
+async function waitForFrame(): Promise<void> {
+  await new Promise<void>((resolve) => {
+    if (typeof window.requestAnimationFrame === 'function') {
+      window.requestAnimationFrame(() => resolve())
+      return
+    }
+
+    setTimeout(resolve, 0)
+  })
+}
+
+async function waitForDialog(): Promise<void> {
+  await waitForFrame()
+  await waitForFrame()
+  await waitForFrame()
+}
+
+function createDialogEvent() {
+  const trigger = document.createElement('button')
+  document.body.appendChild(trigger)
+  return new MouseEvent('click', { bubbles: true, composed: true })
+}
+
+describe('Heading edit dialog', () => {
+  const originalCreateObjectURL = URL.createObjectURL
+  const originalRevokeObjectURL = URL.revokeObjectURL
+
+  beforeEach(() => {
+    mockProcessHeadingMutations.mockReset()
+    mockUploadPhotoFile.mockReset()
+    mockDeletePhotoFile.mockReset()
+    mockResolvePhotoDisplaySrc.mockReset()
+    mockInvalidateResolvedPhotoDisplaySrc.mockReset()
+
+    mockProcessHeadingMutations.mockResolvedValue(undefined)
+    mockUploadPhotoFile.mockResolvedValue('https://example.com/profile/avatar.png')
+    mockDeletePhotoFile.mockResolvedValue(undefined)
+    mockResolvePhotoDisplaySrc.mockImplementation(actualImageHelpers.resolvePhotoDisplaySrc)
+    mockInvalidateResolvedPhotoDisplaySrc.mockImplementation(actualImageHelpers.invalidateResolvedPhotoDisplaySrc)
+
+    Object.defineProperty(URL, 'createObjectURL', {
+      configurable: true,
+      value: jest.fn(() => 'blob:heading-preview')
+    })
+    Object.defineProperty(URL, 'revokeObjectURL', {
+      configurable: true,
+      value: jest.fn()
+    })
+
+    document.body.innerHTML = ''
+  })
+
+  afterEach(() => {
+    document.body.innerHTML = ''
+    actualImageHelpers.invalidateResolvedPhotoDisplaySrc('https://example.com/profile/original.png')
+    actualImageHelpers.invalidateResolvedPhotoDisplaySrc('https://example.com/profile/existing.png')
+    actualImageHelpers.invalidateResolvedPhotoDisplaySrc('https://example.com/private/avatar.png')
+
+    Object.defineProperty(URL, 'createObjectURL', {
+      configurable: true,
+      value: originalCreateObjectURL
+    })
+    Object.defineProperty(URL, 'revokeObjectURL', {
+      configurable: true,
+      value: originalRevokeObjectURL
+    })
+
+    jest.restoreAllMocks()
+  })
+
+  it('keeps the selected heading photo visible in the preview frame before save', async () => {
+    const store = graph() as any
+    const subject = sym('https://example.com/profile/card#me')
+    const profileData: ProfileDetails = {
+      entryNode: subject,
+      name: 'Jane Doe',
+      imageSrc: 'https://example.com/profile/original.png'
+    }
+
+    const resultPromise = createHeadingEditDialog(createDialogEvent(), store, subject, profileData, 'owner')
+    await flushUi()
+
+    const uploadButton = document.querySelector('.profile-edit-dialog__image-upload-button') as HTMLElement | null
+    expect(uploadButton).not.toBeNull()
+
+    uploadButton?.click()
+    await flushUi()
+
+    const fileInput = document.querySelector('input[type="file"]') as HTMLInputElement | null
+    expect(fileInput).not.toBeNull()
+
+    const file = new File(['image-bytes'], 'avatar.png', { type: 'image/png' })
+    Object.defineProperty(fileInput as HTMLInputElement, 'files', {
+      configurable: true,
+      value: [file]
+    })
+
+    fileInput?.dispatchEvent(new Event('change', { bubbles: true }))
+    await flushUi()
+
+    const heroImage = document.querySelector('.profile-edit-dialog__image-frame .profile__hero') as HTMLImageElement | null
+    expect(mockUploadPhotoFile).not.toHaveBeenCalled()
+    expect(URL.createObjectURL).toHaveBeenCalledWith(file)
+    expect(heroImage?.getAttribute('src')).toBe('blob:heading-preview')
+
+    getSharedDialogSaveButton(document)?.click()
+    await resultPromise
+
+    expect(mockUploadPhotoFile).toHaveBeenCalledTimes(1)
+    expect(mockUploadPhotoFile).toHaveBeenCalledWith(store, subject, file)
+  })
+
+  it('shows an existing heading photo in the edit dialog when the display source resolves', async () => {
+    const store = graph() as any
+    const subject = sym('https://example.com/profile/card#me')
+    const profileData: ProfileDetails = {
+      entryNode: subject,
+      name: 'Jane Doe',
+      imageSrc: 'https://example.com/profile/existing.png'
+    }
+    mockResolvePhotoDisplaySrc.mockResolvedValueOnce('blob:existing-heading-preview')
+
+    const resultPromise = createHeadingEditDialog(createDialogEvent(), store, subject, profileData, 'owner')
+    await flushUi()
+
+    const heroImage = document.querySelector('.profile-edit-dialog__image-frame .profile__hero') as HTMLImageElement | null
+    expect(mockResolvePhotoDisplaySrc).toHaveBeenCalledWith(store, 'https://example.com/profile/existing.png')
+    expect(heroImage?.getAttribute('src')).toBe('blob:existing-heading-preview')
+
+    getSharedDialogCancelButton(document)?.click()
+    await resultPromise
+  })
+
+  it('persists default heading phone and email types when existing values have no stored type', async () => {
+    const store = graph() as any
+    const subject = sym('https://example.com/profile/card#me')
+    const profileData: ProfileDetails = {
+      entryNode: subject,
+      name: 'Jane Doe',
+      primaryPhone: {
+        entryNode: sym('https://example.com/profile/card#phone'),
+        type: undefined as any,
+        valueNode: sym('tel:5551234567')
+      },
+      primaryEmail: {
+        entryNode: sym('https://example.com/profile/card#email'),
+        type: undefined as any,
+        valueNode: sym('mailto:jane@example.com')
+      }
+    }
+
+    const resultPromise = createHeadingEditDialog(createDialogEvent(), store, subject, profileData, 'owner')
+    await flushUi()
+
+    getSharedDialogSaveButton(document)?.click()
+    await resultPromise
+
+    expect(mockProcessHeadingMutations).toHaveBeenCalledTimes(1)
+    const plan = mockProcessHeadingMutations.mock.calls[0][2]
+    expect(plan.phoneOps.update).toHaveLength(1)
+    expect(plan.phoneOps.update[0]?.type).toBe('Cell')
+    expect(plan.emailOps.update).toHaveLength(1)
+    expect(plan.emailOps.update[0]?.type).toBe('Home')
+  })
+
+  it('does not revoke the resolved original photo blob when remove is cancelled', async () => {
+    const fetchSpy = jest.spyOn((context.session.store.fetcher as any), '_fetch').mockResolvedValue({
+      ok: true,
+      blob: async () => new Blob(['image-bytes'], { type: 'image/png' })
+    } as Response)
+
+    const createObjectUrlMock = jest.fn(() => 'blob:resolved-original')
+    const revokeObjectUrlMock = jest.fn()
+
+    Object.defineProperty(URL, 'createObjectURL', {
+      configurable: true,
+      value: createObjectUrlMock
+    })
+    Object.defineProperty(URL, 'revokeObjectURL', {
+      configurable: true,
+      value: revokeObjectUrlMock
+    })
+
+    const profile = {
+      entryNode: sym('https://example.com/profile#entry'),
+      name: 'Jane Doe',
+      nickname: 'Jane',
+      imageSrc: 'https://example.com/private/avatar.png',
+      location: 'Amsterdam',
+      pronouns: 'She/Her'
+    }
+
+    const openOnce = createHeadingEditDialog(
+      new Event('click'),
+      context.session.store as any,
+      viewedSubject,
+      profile as any,
+      'owner'
+    )
+
+    await waitForDialog()
+
+    const removeButton = document.querySelector('.profile-edit-dialog__image-remove-button') as HTMLElement | null
+    expect(removeButton).not.toBeNull()
+    removeButton?.click()
+
+    getSharedDialogCancelButton(document)?.click()
+    await expect(openOnce).resolves.toBeUndefined()
+
+    expect(fetchSpy).toHaveBeenCalledWith('https://example.com/private/avatar.png')
+    expect(revokeObjectUrlMock).not.toHaveBeenCalledWith('blob:resolved-original')
+
+    const openTwice = createHeadingEditDialog(
+      new Event('click'),
+      context.session.store as any,
+      viewedSubject,
+      profile as any,
+      'owner'
+    )
+
+    await waitForDialog()
+
+    const reopenedImage = document.querySelector('#profile-modal img.profile__hero') as HTMLImageElement | null
+    expect(reopenedImage?.getAttribute('src')).toBe('blob:resolved-original')
+
+    getSharedDialogCancelButton(document)?.click()
+    await expect(openTwice).resolves.toBeUndefined()
+  })
+})

--- a/test/heading-edit-dialog.test.ts
+++ b/test/heading-edit-dialog.test.ts
@@ -147,6 +147,77 @@ describe('Heading edit dialog', () => {
     expect(mockUploadPhotoFile).toHaveBeenCalledWith(store, subject, file)
   })
 
+  it('keeps the captured camera photo visible in the preview frame before save', async () => {
+    const store = graph() as any
+    const subject = sym('https://example.com/profile/card#me')
+    const profileData: ProfileDetails = {
+      entryNode: subject,
+      name: 'Jane Doe',
+      imageSrc: 'https://example.com/profile/original.png'
+    }
+
+    const resultPromise = createHeadingEditDialog(createDialogEvent(), store, subject, profileData, 'owner')
+    await flushUi()
+
+    const cameraButton = document.querySelector('.profile-edit-dialog__image-camera-button') as HTMLElement | null
+    expect(cameraButton).not.toBeNull()
+
+    cameraButton?.click()
+    await flushUi()
+
+    const photoCapture = document.querySelector('solid-ui-photo-capture') as HTMLElement | null
+    expect(photoCapture).not.toBeNull()
+
+    const file = new File(['camera-image-bytes'], 'camera.png', { type: 'image/png' })
+    photoCapture?.dispatchEvent(new CustomEvent('photo-captured', {
+      detail: { file },
+      bubbles: true
+    }))
+    await flushUi()
+
+    const heroImage = document.querySelector('.profile-edit-dialog__image-frame .profile__hero') as HTMLImageElement | null
+    expect(mockUploadPhotoFile).not.toHaveBeenCalled()
+    expect(URL.createObjectURL).toHaveBeenCalledWith(file)
+    expect(heroImage?.getAttribute('src')).toBe('blob:heading-preview')
+
+    getSharedDialogSaveButton(document)?.click()
+    await resultPromise
+
+    expect(mockUploadPhotoFile).toHaveBeenCalledTimes(1)
+    expect(mockUploadPhotoFile).toHaveBeenCalledWith(store, subject, file)
+  })
+
+  it('only persists removing the heading photo when save is pressed', async () => {
+    const store = graph() as any
+    const subject = sym('https://example.com/profile/card#me')
+    const profileData: ProfileDetails = {
+      entryNode: subject,
+      name: 'Jane Doe',
+      imageSrc: 'https://example.com/profile/original.png'
+    }
+
+    const resultPromise = createHeadingEditDialog(createDialogEvent(), store, subject, profileData, 'owner')
+    await flushUi()
+
+    const removeButton = document.querySelector('.profile-edit-dialog__image-remove-button') as HTMLElement | null
+    expect(removeButton).not.toBeNull()
+
+    removeButton?.click()
+    await flushUi()
+
+    expect(mockProcessHeadingMutations).not.toHaveBeenCalled()
+    expect(mockInvalidateResolvedPhotoDisplaySrc).not.toHaveBeenCalled()
+
+    getSharedDialogSaveButton(document)?.click()
+    await resultPromise
+
+    expect(mockProcessHeadingMutations).toHaveBeenCalledTimes(1)
+    const plan = mockProcessHeadingMutations.mock.calls[0][2]
+    expect(plan.basicOps.update).toHaveLength(1)
+    expect(plan.basicOps.update[0]?.imageSrc).toBe('')
+    expect(mockInvalidateResolvedPhotoDisplaySrc).toHaveBeenCalledWith('https://example.com/profile/original.png')
+  })
+
   it('shows an existing heading photo in the edit dialog when the display source resolves', async () => {
     const store = graph() as any
     const subject = sym('https://example.com/profile/card#me')


### PR DESCRIPTION
This PR does a couple of things.
- When the user clicks remove, cancels, and then re-enters the dialog the original image now resolves (instead of default from previous removal)
- When the user uploads or removes a photo data does not automatically persist it waits for user to click Save Changes.
- No longer deletes photos when removing or uploading a new one, leaves them to be used at a later time.
- Minor test refactor of image helpers tests existing in the phone test, moved to a heading edit dialog general testing.
- Tests to ensure this behavior.