### PR TITLE
Fix QR code sizing

### DIFF
--- a/src/sections/qrcode/QRCodeCard.ts
+++ b/src/sections/qrcode/QRCodeCard.ts
@@ -99,10 +99,12 @@ function firstContactValue(
 
 const qrCodeRenderOptions = {
   type: 'svg' as const,
+  margin: 0,
+  width: 151,
   color: {
     dark: '#000000',
-    light: '#ffffff'
-  }
+    light: '#ffffff00',
+  },
 }
 
 function renderQRCodeSvg(value: string): Promise<string> {

--- a/src/sections/qrcode/QRCodeSection.css
+++ b/src/sections/qrcode/QRCodeSection.css
@@ -6,10 +6,7 @@
   --qrcode-card-caption-size: var(--font-size-md, 1rem);
   --qrcode-card-caption-size-compact: var(--font-size-sm, 0.875rem);
   --qrcode-card-caption-weight: var(--font-weight-md, 500);
-  --qrcode-card-image-padding-top: 1rem;
-  --qrcode-card-image-padding-right: 1rem;
-  --qrcode-card-image-padding-bottom: 1.0625rem;
-  --qrcode-card-image-padding-left: 1.0625rem;
+  --qrcode-card-image-padding: 1.0625rem;
   --qrcode-card-frame-border: var(--border-width-thin, 0.1rem) solid var(--color-border, var(--gray-200, #E5E7EB));
   --qrcode-card-frame-background: var(--color-surface-framed-content, #F3F4F6);
   --qrcode-section-padding-compact: var(--spacing-sm, 0.938rem);
@@ -39,11 +36,7 @@
 
 .qrcode-card__frame {
   margin: 0;
-  padding:
-    var(--qrcode-card-image-padding-top)
-    var(--qrcode-card-image-padding-right)
-    var(--qrcode-card-image-padding-bottom)
-    var(--qrcode-card-image-padding-left);
+  padding: var(--qrcode-card-image-padding);
   border-radius: var(--border-radius-base, 0.3125rem);
   border: var(--qrcode-card-frame-border);
   background: var(--qrcode-card-frame-background);
@@ -80,6 +73,10 @@
     padding: var(--qrcode-section-padding-compact);
     gap: var(--qrcode-section-gap-compact);
   }
+
+  .qrcode-card__image svg {
+      max-width: 120px;
+  }
 }
 
 :is(.profile-pane-host, .profile-pane-root)[data-layout='mobile'] .qrcode-card__caption {
@@ -94,6 +91,10 @@
     align-self: stretch;
     padding: var(--qrcode-section-padding-compact);
     gap: var(--qrcode-section-gap-compact);
+  }
+
+  .qrcode-card__image svg {
+    max-width: 120px;
   }
 
   .qrcode-card__caption {

--- a/src/sections/qrcode/QRCodeSection.css
+++ b/src/sections/qrcode/QRCodeSection.css
@@ -73,10 +73,6 @@
     padding: var(--qrcode-section-padding-compact);
     gap: var(--qrcode-section-gap-compact);
   }
-
-  .qrcode-card__image svg {
-      max-width: 120px;
-  }
 }
 
 :is(.profile-pane-host, .profile-pane-root)[data-layout='mobile'] .qrcode-card__caption {
@@ -91,10 +87,6 @@
     align-self: stretch;
     padding: var(--qrcode-section-padding-compact);
     gap: var(--qrcode-section-gap-compact);
-  }
-
-  .qrcode-card__image svg {
-    max-width: 120px;
   }
 
   .qrcode-card__caption {


### PR DESCRIPTION
## Summary
- use transparent hex for QR code background
- normalize QR card image padding
- constrain QR image size on compact/mobile layouts