### PR TITLE
Fix Dialogs

### DIFF
--- a/src/ui/dialog.css
+++ b/src/ui/dialog.css
@@ -27,7 +27,7 @@
   display: grid;
   place-items: center;
   overscroll-behavior: contain;
-  padding-top: env(safe-area-inset-top);
+  padding-top: max(25px, env(safe-area-inset-top));
   padding-right: 0;
   padding-bottom: max(25px, env(safe-area-inset-bottom));
   padding-left: 0;
@@ -55,6 +55,7 @@
   overflow: hidden;
   box-shadow: var(--box-shadow-modal, 0 2px 10px rgba(0, 0, 0, 0.3));
   align-self: center;
+  justify-self: center;
 }
 
 #profile-modal .modal .modal-header {

--- a/src/ui/dialog.responsive.css
+++ b/src/ui/dialog.responsive.css
@@ -8,7 +8,7 @@
 @media (max-width: 576px) {
   #profile-modal {
     --profile-modal-panel-max-height: calc(100dvh - 4 * 15px);
-    padding-top: env(safe-area-inset-top);
+    padding-top: max(15px, env(safe-area-inset-top));
     padding-right: 0;
     padding-bottom: max(15px, env(safe-area-inset-bottom));
     padding-left: 0;
@@ -69,7 +69,7 @@
 
 html[data-layout='mobile'] #profile-modal {
   --profile-modal-panel-max-height: calc(100dvh - 4 * 15px);
-  padding-top: env(safe-area-inset-top);
+  padding-top: max(15px, env(safe-area-inset-top));
   padding-right: 0;
   padding-bottom: max(15px, env(safe-area-inset-bottom));
   padding-left: 0;
@@ -132,7 +132,7 @@ html[data-layout='mobile'] #profile-modal #modal-buttons > solid-ui-button {
 @container profile-pane (max-width: 576px) {
   #profile-modal {
     --profile-modal-panel-max-height: calc(100dvh - 4 * 15px);
-    padding-top: env(safe-area-inset-top);
+    padding-top: max(15px, env(safe-area-inset-top));
     padding-right: 0;
     padding-bottom: max(15px, env(safe-area-inset-bottom));
     padding-left: 0;


### PR DESCRIPTION
Heading, Resume and contacts dialogs were attaching themselves to the top of the window.